### PR TITLE
Use looser dependencies on request and bluebird

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "author": "Ty Abonil",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "~1.0.1",
-    "request": "~2.33.0"
+    "bluebird": "^1.2",
+    "request": "^2.34"
   },
   "devDependencies": {
     "mocha": "~1.17.1",


### PR DESCRIPTION
This is the intended use of the “compatible with” semver caret operator.

This is a great little microlib, but with your current versioning constraints, your lib will get out of sync with the versions of Bluebird promises that someone is using in their own code (and they'll lose any new features in Request.) Your code looks simple enough that it should be reasonably safe to expect Request's and Bluebird's relevant APIs not to change, at least until a new major version of either one.

This should save you (or me ;) having to worry about updating these too often.
