### PR TITLE
Send more information in reject

### DIFF
--- a/lib/rp.js
+++ b/lib/rp.js
@@ -26,12 +26,14 @@ function rp(options) {
             if (error) {
                 reject({
                     error: error,
-                    options: c
+                    options: c,
+                    response: response
                 });
             } else if (c.simple && (statusCodes[c.method].indexOf(response.statusCode) === -1)) {
                 reject({
                     error: body,
                     options: c,
+                    response: response,
                     statusCode: response.statusCode
                 });
             } else {


### PR DESCRIPTION
I've found the need for seeing more information about the request/response when there's an error, especially when debugging.

This pull request simply sends more data back in the reject.

This will require bumping the version and republishing (make sure to `git push --tags`).

Tests pass. Thx!
