### PR TITLE
Exposing the whole request interface

### DIFF
--- a/lib/rp.js
+++ b/lib/rp.js
@@ -1,5 +1,6 @@
 var Promise = require('bluebird'),
-    request = require('request');
+    request = require('request'),
+    util = require('util');
 
 var statusCodes = {
     'GET' : [200],


### PR DESCRIPTION
There are too many methods that the current implementation doesn't expose, such as defaults, post, get and so on.

This change will copy every method from request to 'rp' and also wire the promise in those that needed.

There are a few changes to make this commit work with the tests folder from 'request' itself, so we could maintain the request-promise based on the 'request' tests.

That way we will have a new implementation of request that conforms with the actual "specification".
