### PR TITLE
Request accepts method name in lower case

### DIFF
--- a/lib/rp.js
+++ b/lib/rp.js
@@ -21,6 +21,7 @@ function rp(options) {
         }
     }
     c.method = c.method || 'GET';
+    c.method = c.method.toUpperCase();
     return new Promise(function (resolve, reject) {
         request(c, function (error, response, body) {
             if (error) {


### PR DESCRIPTION
This fix prevent the 'indexOf undefined' that should append.
