### PR TITLE
Support PATCH

### DIFF
--- a/lib/rp.js
+++ b/lib/rp.js
@@ -2,14 +2,7 @@ var Promise = require('bluebird'),
     request = require('request');
 
 function rp(options) {
-        var statusCodes = {
-        'GET' : [200],
-        'HEAD' : [200],
-        'PUT' : [200, 201],
-        'POST' : [200, 201],
-        'PATCH' : [200, 201],
-        'DELETE' : [200, 201]
-    }, c = {simple: true}, i;
+    var c = {simple: true}, i;
     if (typeof options === 'string') {
         c.uri = options;
         c.method = 'GET';
@@ -30,7 +23,7 @@ function rp(options) {
                     options: c,
                     response: response
                 });
-            } else if (c.simple && (statusCodes[c.method].indexOf(response.statusCode) === -1)) {
+            } else if (c.simple && !(/^2/.test('' + response.statusCode))) {
                 reject({
                     error: body,
                     options: c,

--- a/test/request-test.js
+++ b/test/request-test.js
@@ -32,6 +32,24 @@ describe('request tests', function () {
             });
     });
 
+    it('should resolve for 201 status code', function (done) {
+        rp('http://localhost:4000/201')
+            .then(function(){
+                done();
+            }).catch(function(){
+                done(new Error('A 201 response should resolve, not reject'));
+            });
+    });
+
+    it('should resolve for 204 status code', function (done) {
+        rp('http://localhost:4000/204')
+            .then(function(){
+                done();
+            }).catch(function(){
+                done(new Error('A 204 response should resolve, not reject'));
+            });
+    });
+
     it('should reject for http errors', function(done){
         rp('http://localhost:1/200')
             .then(function(){


### PR DESCRIPTION
This PR also treats all `2xx` responses as `resolve` conditions when using 'simple' semantics.
