### PR TITLE
Optionally resolve promise with full response object instead of the body

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,21 @@
 
 A Promises/A XHR wrapper for Bluebird and Request
 
-[Bluebird](https://github.com/petkaantonov/bluebird) and [Request](https://github.com/mikeal/request) are pretty awesome, but I found myself using the same design pattern.  This is a simple wrapper that takes in a request options object (or URI string), and returns a chainable promise.  By default, http response codes other than 200 and 201 will cause the promise to be rejected.  This can be over-ridden by setting `options.simple` to `false`.
+[Bluebird](https://github.com/petkaantonov/bluebird) and
+[Request](https://github.com/mikeal/request) are pretty awesome, but I found
+myself using the same design pattern.  This is a simple wrapper that takes in a
+request options object (or URI string), and returns a chainable promise.  By
+default, http response codes other than 2xx will cause the promise to
+be rejected.  This can be over-ridden by setting `options.simple` to `false`.
 
 Note: As of version 0.1, `reject` now passes  an object containing the following:
 ```js    
     reject({
-                    error: body,
-                    options: c,
-                    response: response,
-                    statusCode: response.statusCode
-                });
+      error: body,
+      options: c,
+      response: response,
+      statusCode: response.statusCode
+    });
 ```
 
 ## Installation
@@ -49,6 +54,18 @@ rp(options)
 //transform is called just before promise is fulfilled
 //displays length of response from server after post
 
+
+// get full response after DELETE
+options = {
+  method: 'DELETE',
+  uri: 'http://my-server/path/to/resource/1234',
+  resolveWithFullResponse: true
+};
+rp(options)
+  .then(function(response) {
+    console.log("DELETE succeeded with status %d", response.statusCode);
+  })
+  .catch(console.error);
 ```
 
 ## MIT Licenced

--- a/lib/rp.js
+++ b/lib/rp.js
@@ -3,7 +3,7 @@ var Promise = require('bluebird'),
     util = require('util');
 
 function rp(options) {
-    var c = {simple: true}, i;
+    var c = {simple: true, resolveWithFullResponse: false}, i;
     if (typeof options === 'string') {
         c.uri = options;
         c.method = 'GET';
@@ -40,6 +40,8 @@ function buildPromise (c, requester) {
             } else {
                 if (c.transform && typeof c.transform === 'function') {
                     resolve(c.transform(body));
+                } else if (c.resolveWithFullResponse) {
+                    resolve(response);
                 } else {
                     resolve(body);
                 }

--- a/test/request-test.js
+++ b/test/request-test.js
@@ -2,6 +2,7 @@ var rp = require('../lib/rp.js');
 var http = require('http');
 var url = require('url');
 var assert = require('assert');
+var util = require('util');
 
 
 describe('request tests', function () {
@@ -14,7 +15,7 @@ describe('request tests', function () {
             var status = parseInt(path.split('/')[1]);
             if(isNaN(status)) status = 555;
             response.writeHead(status);
-            response.end();
+            response.end("Hello world!");
         });
         server.listen(4000);
     });
@@ -111,6 +112,33 @@ describe('request tests', function () {
                     done();
                 }).catch(function(){
                     done(new Error('A 200 response code for a DELETE request should resolve, not reject'));
+                });
+        });
+    });
+
+    describe('resolveWithFullResponse', function(){
+        it('should include the response', function(done){
+            var options = {
+                url: 'http://localhost:4000/200',
+                method: 'GET',
+                resolveWithFullResponse: true
+            };
+            rp(options)
+                .then(function(response){
+                    if (response.statusCode !== 200) {
+                        done(new Error(util.format("Expected response status %d, got %d", 200, response.statusCode)));
+                    }
+                    else if (response.request.method !== 'GET') {
+                        done(new Error(util.format("Expected method %s, got %s", 'GET', response.request.method))); 
+                    }
+                    else if (response.body !== 'Hello world!') {
+                        done(new Error(util.format("Expected body as '%s', got '%s'", "Hello world!", response.body)));
+                    }
+                    else {
+                        done();
+                    }
+                }).catch(function(err){
+                    done(new Error(err));
                 });
         });
     });


### PR DESCRIPTION
Enabled by new option "resolveWithFullResponse" (defaults to false), user can opt-in to resolving the request with a full response object instead of just the body. This gives the user the option to pass-through or switch on things like the status code.

See also: https://github.com/tyabonil/request-promise/issues/4
