### PR TITLE
Fix .defaults({opt: value}) erasing base options

### DIFF
--- a/lib/rp.js
+++ b/lib/rp.js
@@ -2,8 +2,10 @@ var Promise = require('bluebird'),
     request = require('request'),
     util = require('util');
 
+var defaultOptions = {simple: true, resolveWithFullResponse: false};
+
 function rp(options) {
-    var c = {simple: true, resolveWithFullResponse: false}, i;
+    var c = defaultOptions, i;
     if (typeof options === 'string') {
         c.uri = options;
         c.method = 'GET';
@@ -81,6 +83,9 @@ Object.keys(request).filter(function(key){
 });
 
 rp.defaults =  function (options, requester) {
+    options.simple = options.simple || defaultOptions.simple;
+    options.resolveWithFullResponse = options.resolveWithFullResponse || defaultOptions.resolveWithFullResponse;
+
     var def = function (method) {
         var d = function (uri, opts, callback) {
             var params = request.initParams(uri, opts, callback)


### PR DESCRIPTION
Using `require('request-promise').defaults({timeout: 2000})` - or any other value - will erase base values used by `require-promise` (simple & resolveWithFullResponse flags right now).

This pull request fixes that.
