### PR TITLE
Expose the internal request component (fixes #23)

### DIFF
--- a/lib/rp.js
+++ b/lib/rp.js
@@ -83,6 +83,8 @@ Object.keys(request).filter(function(key){
     rp[key] = defaultHttpMethod(key);
 });
 
+rp.request = request;
+
 rp.defaults =  function (options, requester) {
     options.simple = options.simple || defaultOptions.simple;
     options.resolveWithFullResponse = options.resolveWithFullResponse || defaultOptions.resolveWithFullResponse;


### PR DESCRIPTION
As we discussed in issue #23, there is a simple way to allow `request-debug` to monitor requests made within `request-promise`, that is exposing the internal `request` and then do:

``` javascript
var rp = require('request-promise');
require('request-debug', rp.request);
```
