### PR TITLE
Require just used functions & use natives

### DIFF
--- a/lib/rp.js
+++ b/lib/rp.js
@@ -2,7 +2,10 @@
 
 var Bluebird = require('./bluebird-fresh.js'),
     CapturedTrace = require('./bluebird-captured-trace-fresh.js'),
-    _ = require('lodash'),
+    assign = require('lodash/object/assign'),
+    isFunction = require('lodash/lang/isFunction'),
+    isPlainObject = require('lodash/lang/isPlainObject'),
+    isString = require('lodash/lang/isString'),
     chalk = require('chalk'),
     errors = require('./errors.js');
 
@@ -11,18 +14,18 @@ var Bluebird = require('./bluebird-fresh.js'),
 var request = (function () {
 
     function clearCache() {
-        _.forEach(_.keys(require.cache), function (key) {
+        Object.keys(require.cache).forEach(function (key) {
             delete require.cache[key];
         });
     }
 
-    var temp = _.assign({}, require.cache);
+    var temp = assign({}, require.cache);
     clearCache();
 
     var freshRequest = require('request');
 
     clearCache();
-    _.assign(require.cache, temp);
+    assign(require.cache, temp);
 
     return freshRequest;
 
@@ -36,7 +39,7 @@ function RP$callback(err, response, body) {
 
     var origCallbackThrewException = false, thrownException;
 
-    if (_.isFunction(self._rp_callbackOrig)) {
+    if (isFunction(self._rp_callbackOrig)) {
         try {
             self._rp_callbackOrig.apply(self, arguments);
         } catch (e) {
@@ -47,7 +50,7 @@ function RP$callback(err, response, body) {
 
     if (err) {
 
-        self._rp_reject(_.assign(new errors.RequestError(err), {
+        self._rp_reject(assign(new errors.RequestError(err), {
             error: err,
             options: self._rp_options,
             response: response
@@ -55,14 +58,14 @@ function RP$callback(err, response, body) {
 
     } else if (self._rp_options.simple && !(/^2/.test('' + response.statusCode))) {
 
-        self._rp_reject(_.assign(new errors.StatusCodeError(response.statusCode, body), {
+        self._rp_reject(assign(new errors.StatusCodeError(response.statusCode, body), {
             error: body,
             options: self._rp_options,
             response: response
         }));
 
     } else {
-        if (_.isFunction(self._rp_options.transform)) {
+        if (isFunction(self._rp_options.transform)) {
             try {
                 self._rp_resolve(self._rp_options.transform(body, response));
             } catch (e) {
@@ -80,7 +83,7 @@ function RP$callback(err, response, body) {
     }
 
     // Mimic original behavior of errors emitted by request with no error listener registered
-    if (err && _.isFunction(self._rp_callbackOrig) === false && self._rp_promise_in_use !== true && self.listeners('error').length === 1) {
+    if (err && isFunction(self._rp_callbackOrig) === false && self._rp_promise_in_use !== true && self.listeners('error').length === 1) {
         throw err;
     }
 
@@ -93,7 +96,7 @@ request.Request.prototype.init = function RP$initInterceptor(options) {
     var self = this;
 
     // Init may be called again - currently in case of redirects
-    if (_.isPlainObject(options) && self._callback === undefined && self._rp_promise === undefined) {
+    if (isPlainObject(options) && self._callback === undefined && self._rp_promise === undefined) {
 
         self._rp_promise = new Bluebird(function (resolve, reject) {
             self._rp_resolve = resolve;
@@ -104,7 +107,7 @@ request.Request.prototype.init = function RP$initInterceptor(options) {
         self._rp_callbackOrig = self.callback;
         self.callback = RP$callback;
 
-        if (_.isString(options.method)) {
+        if (isString(options.method)) {
             options.method = options.method.toUpperCase();
         }
 
@@ -128,7 +131,7 @@ function expose(methodToExpose, exposeAs) {
     exposeAs = exposeAs || methodToExpose;
 
     /* istanbul ignore if */
-    if (!_.isUndefined(request.Request.prototype[exposeAs])) {
+    if (request.Request.prototype[exposeAs] !== undefined) {
         console.error(chalk.bold.bgRed('[Request-Promise] Unable to expose method "' + exposeAs + '". It is already implemented by Request. Please visit https://github.com/request/request-promise/wiki/Troubleshooting'));
         return;
     }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "bluebird": "^2.3",
     "chalk": "1.0.x",
-    "lodash": "3.6.x",
+    "lodash": "^3.6.0",
     "request": "^2.34"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi,

I made this because after a few requests using this module, lodash was causing some memory allocation problems, the full file is very big and it was causing me problems.

I don't quite understand why, but make just these changes, requiring just the used functions and using a few native functions, my application decrease the memory allocation from 500mb to 220mb.