### PR TITLE
Remove explicit CLS dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Consider Request-Promise being:
 	- `resolveWithFullResponse` which is a boolean to set whether the promise should be resolve with the full response or just the response body
 	- `transform` which takes a function to transform the response into a custom value with which the promise is resolved
 
-The objects returned by request calls like `rp(...)` or e.g. `rp.post(...)` are regular Promises/A+ compliant promises and can be assimilated by any compatible promise library. 
+The objects returned by request calls like `rp(...)` or e.g. `rp.post(...)` are regular Promises/A+ compliant promises and can be assimilated by any compatible promise library.
 
 The methods `.then(...)`, `.catch(...)`, and `.finally(...)` - which you can call on the request call objects - return a full-fledged Bluebird promise. That means you have the full [Bluebird API](https://github.com/petkaantonov/bluebird/blob/master/API.md) available for further chaining. E.g.: `rp(...).then(...).spread(...)` If, however, you need a method other than `.then(...)`, `.catch(...)`, or `.finally(...)` to be **FIRST** in the chain, use `.promise()`: `rp(...).promise().bind(...).then(...)`
 
@@ -427,7 +427,7 @@ function reverseBody(body, response, resolveWithFullResponse) {
 
 ## Experimental Support for Continuation Local Storage
 
-Continuation Local Storage (CLS) is a great mechanism for backpacking data along asynchronous call chains that is best explained in [these slides](http://fredkschott.com/post/2014/02/conquering-asynchronous-context-with-cls/). If you want to use CLS you need to install the [continuation-local-storage package](https://www.npmjs.com/package/continuation-local-storage). Request-Promise internally uses the [cls-bluebird package](https://www.npmjs.com/package/cls-bluebird) to enable CLS also within the Bluebird promises.
+Continuation Local Storage (CLS) is a great mechanism for backpacking data along asynchronous call chains that is best explained in [these slides](http://fredkschott.com/post/2014/02/conquering-asynchronous-context-with-cls/). If you want to use CLS you need to install the [continuation-local-storage package](https://www.npmjs.com/package/continuation-local-storage) and the [cls-bluebird package](https://www.npmjs.com/package/cls-bluebird).
 
 Just call `rp.bindCLS(ns)` **ONCE** before your first request to activate CLS:
 ``` js

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "bluebird": "^2.3",
-    "cls-bluebird": "^1.0.1",
     "lodash": "^3.10.0",
     "request": "^2.34"
   },
@@ -40,6 +39,7 @@
     "chai-as-promised": "5.1.x",
     "chalk": "^1.1.1",
     "cheerio": "^0.19.0",
+    "cls-bluebird": "^1.0.1",
     "continuation-local-storage": "^3.1.4",
     "event-stream": "3.3.x",
     "gulp": "3.9.x",


### PR DESCRIPTION
As suggested in #70.  People that want to use CLS can take the dependency themselves.