### PR TITLE
Adding experimental file

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,11 +427,11 @@ function reverseBody(body, response, resolveWithFullResponse) {
 
 ## Experimental Support for Continuation Local Storage
 
-Continuation Local Storage (CLS) is a great mechanism for backpacking data along asynchronous call chains that is best explained in [these slides](http://fredkschott.com/post/2014/02/conquering-asynchronous-context-with-cls/). If you want to use CLS you need to install the [continuation-local-storage package](https://www.npmjs.com/package/continuation-local-storage) and the [cls-bluebird package](https://www.npmjs.com/package/cls-bluebird).
+Continuation Local Storage (CLS) is a great mechanism for backpacking data along asynchronous call chains that is best explained in [these slides](http://fredkschott.com/post/2014/02/conquering-asynchronous-context-with-cls/). If you want to use CLS you need to install the [continuation-local-storage package](https://www.npmjs.com/package/continuation-local-storage) and the [cls-bluebird package](https://www.npmjs.com/package/cls-bluebird). Also, include `request-promise/lib/experimental` instead of `request-promise`.   
 
 Just call `rp.bindCLS(ns)` **ONCE** before your first request to activate CLS:
 ``` js
-var rp = require('request-promise');
+var rp = require('request-promise/lib/experimental');
 var cls = require('continuation-local-storage');
 
 var ns = cls.createNamespace('testNS');

--- a/lib/experimental.js
+++ b/lib/experimental.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var request = require('./rp');
+
+/* istanbul ignore next */ // Function covered but not seen by Instanbul.
+request.bindCLS = function RP$bindCLS(ns) {
+    require('cls-bluebird')(ns);
+};
+
+module.exports = request;

--- a/lib/rp.js
+++ b/lib/rp.js
@@ -147,11 +147,4 @@ request.Request.prototype.promise = function RP$promise() {
     return this._rp_promise;
 };
 
-
-/* istanbul ignore next */ // Function covered but not seen by Instanbul.
-request.bindCLS = function RP$bindCLS(ns) {
-    require('cls-bluebird')(ns);
-};
-
-
 module.exports = request;

--- a/test/fixtures/cls/single-namespace.js
+++ b/test/fixtures/cls/single-namespace.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var rp = require('../../../lib/rp.js');
+var rp = require('../../../lib/experimental.js');
 var cls = require('continuation-local-storage');
 
 


### PR DESCRIPTION
This PR is intended to fix #91.
The point is to keep the experimental feature as an option and not mandatory. In the current solution, all the projects need to install `cls-bluebird` or ignore the dependency somehow in their build process.

My proposal is to leave that experimental feature optional:
```js
//Include request-promise without experimental feature
var rp = require('request-promise');

//Include request-promise with experimental feature
var rp = require('request-promise/lib/experimental');
``` 

Please, if anybody has any concerns, let me know.