### PR TITLE
Update required "request" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "bluebird": "^2.3",
     "lodash": "^4.5.0",
-    "request": "^2.34"
+    "request": "^2.69.0"
   },
   "devDependencies": {
     "body-parser": "1.15.x",


### PR DESCRIPTION
2.69.0 supports features such as baseUrl. In projects with other versions of request being used, the request version used by request-promise is falling back to other versions that don't support these newer features.