### PR TITLE
MYCS-3578 test and contract for client-side cache

### DIFF
--- a/lib/rp.js
+++ b/lib/rp.js
@@ -10,6 +10,10 @@ var Bluebird = require('bluebird'),
     keys = require('lodash/keys'),
     errors = require('./errors.js');
 
+// Used to handle HTTP 1.1 Cache
+var moment = require('moment'),
+    Cache = require('memory-cache');
+
 
 // Load Request freshly - so that users can require an unaltered request instance!
 var request = (function () {
@@ -39,6 +43,16 @@ var defaultTransformations = {
     }
 };
 
+var _computeAgeOfEntry = function (entry, now) {
+
+  var created_at = moment(entry.created_at);
+  var age = moment.duration(now.diff(entry.created_at)).asSeconds();
+
+  // normalize the age in seconds
+  age = -Math.floor(-age);
+  entry.content.headers.age = age;
+};
+
 function RP$callback(err, response, body) {
 
     /* jshint validthis:true */
@@ -55,6 +69,8 @@ function RP$callback(err, response, body) {
         }
     }
 
+
+
     if (err) {
 
         self._rp_reject(new errors.RequestError(err, self._rp_options, response));
@@ -64,7 +80,7 @@ function RP$callback(err, response, body) {
         if (isFunction(self._rp_options.transform)) {
 
             (new Bluebird(function (resolve) {
-                resolve(self._rp_options.transform(body, response, self._rp_options.resolveWithFullResponse)); // transform may return a Promise
+                resolve(self._rp_options.transform(response.body, response, self._rp_options.resolveWithFullResponse)); // transform may return a Promise
             }))
                 .then(function (transformedResponse) {
                     self._rp_reject(new errors.StatusCodeError(response.statusCode, body, self._rp_options, transformedResponse));
@@ -78,6 +94,8 @@ function RP$callback(err, response, body) {
         }
 
     } else {
+
+
 
         if (isFunction(self._rp_options.transform)) {
 
@@ -105,6 +123,121 @@ function RP$callback(err, response, body) {
 
 }
 
+
+/**
+ * HTTP 1.1 Cache handling
+ */
+// Cache.debug(true);
+
+var LAST_MODIFIED_FORMAT = 'ddd, DD MMM YYYY HH:mm:ss z';
+var isResolveWithFullResponseSet = false;
+
+
+var _useInMemoryCache = function (requestOpts) {
+    return !isUndefined(requestOpts.cache) && requestOpts.cache === true && (isUndefined(requestOpts.method) || requestOpts.method.toUpperCase() === 'GET');
+};
+
+
+
+var _httpCacheHandler = function (response) {
+    var now = moment();
+
+    // 304 response means we can reuse the cache entry we already had
+    if (response && response.statusCode === 304) {
+        var cacheEntry = Cache.get('GET:' + response.request.uri.href);
+        if (!cacheEntry) {
+            throw new Error(response.request.uri.href + ' should have exit in the cache but it is not there');
+        }
+
+        cacheEntry.created_at = now;
+        _computeAgeOfEntry(cacheEntry, now);
+        response = cacheEntry.content;
+
+        return isResolveWithFullResponseSet ? response : response.body;
+    }
+
+    // Restore option to its original state
+    this._rp_options.resolveWithFullResponse = isResolveWithFullResponseSet;
+
+    var useCache = true;
+    var headers = response.headers;
+    var cacheKey = 'GET:' + response.request.href;
+
+    // Don't cache if Cache-Control doesn't exist
+    if (isUndefined(headers['cache-control'])) {
+        useCache = false;
+    }
+
+    // Don't cache on Cache-Control.no-cache
+    if (!isUndefined(headers['cache-control']) && /no-cache/.test(headers['cache-control'])) {
+        useCache = false;
+    }
+
+    // Don't cache if Cache-Control.max-age doesn't exist
+    if (!isUndefined(headers['cache-control']) && !/max-age=(\d+)/.test(headers['cache-control'])) {
+        useCache = false;
+    }
+
+    // Don't cache if Cache-Control.max-age is 0
+    if (!isUndefined(headers['cache-control']) && /max-age=0/.test(headers['cache-control'])) {
+        useCache = false;
+    }
+
+    if (useCache) {
+
+        var age = !isUndefined(headers['age']) ? headers['age'] : 0,
+            maxAge = parseInt(headers['cache-control'].match(/max-age=(\d+)/)[1]),
+            lastModified;
+
+        // Get Last-Modified
+        if (isUndefined(headers['last-modified'])) {
+            lastModified = headers['last-modified'];
+        }
+
+        if (maxAge > 0) {
+            var createdAt = moment(now).subtract(age, 's');  // we reduce created_at from age to have a
+                                                             // consistent age with the backend
+            var value = {
+                max_age: maxAge,
+                content: response,
+                created_at: createdAt,
+                last_modified: lastModified || createdAt
+            };
+
+            // Add/Update entry age
+            _computeAgeOfEntry(value, now);
+
+            // This insert will also refresh `created_at` in case of 304 responses
+            Cache.put(cacheKey, value);
+        }
+    }
+
+    // Add age if undefined
+    response.headers.age = headers['age'] || 0;
+
+    // @TODO This return is being ignored
+    return isResolveWithFullResponseSet ? response : response.body;
+};
+
+
+var _isCacheStale = function (cachedResponse) {
+
+    if (cachedResponse) {
+        var now = moment();
+        _computeAgeOfEntry(cachedResponse, now);
+
+        // Check if cache entry is a stale
+        if (cachedResponse.content.headers.age > cachedResponse.max_age) {
+            return cachedResponse.last_modified.format(LAST_MODIFIED_FORMAT);
+        }
+    }
+
+    return false;
+};
+
+//
+// Init
+//
 var originalInit = request.Request.prototype.init;
 
 request.Request.prototype.init = function RP$initInterceptor(options) {
@@ -112,12 +245,55 @@ request.Request.prototype.init = function RP$initInterceptor(options) {
     var self = this;
 
     // Init may be called again - currently in case of redirects
-    if (isPlainObject(options) && self._callback === undefined && self._rp_promise === undefined) {
+    if (isPlainObject(options) && isUndefined(self._callback) && isUndefined(self._rp_promise)) {
 
-        self._rp_promise = new Bluebird(function (resolve, reject) {
-            self._rp_resolve = resolve;
-            self._rp_reject = reject;
-        });
+        var cachedResponse = null;
+
+        if (_useInMemoryCache(options)) {
+            cachedResponse = Cache.get('GET:' + options.uri);
+
+            // Store current status of `resolveWithFullResponse`
+            isResolveWithFullResponseSet = options.resolveWithFullResponse || false;
+
+            // Force resolveWithFullResponse to have access to the response header
+            options.resolveWithFullResponse = true;
+
+            if (cachedResponse) {
+                var lastModified = _isCacheStale(cachedResponse);
+
+                // Return cached resource if not stale
+                if (!lastModified) {
+                    _computeAgeOfEntry(cachedResponse, moment());
+
+                    self._rp_promise = new Bluebird(function (resolve) {
+                      resolve(isResolveWithFullResponseSet ? cachedResponse.content : cachedResponse.content.body);
+                    });
+
+                    return;
+                } else {
+                    // Add pre-flight header
+                    options.headers = options.headers || {};
+                    options.headers['If-Modified-Since'] = lastModified;
+
+                    var etag = cachedResponse.content && cachedResponse.content.headers &&
+                        cachedResponse.content.headers['etag'];
+                    if ( etag ) {
+                        options.headers['If-None-Match'] = etag;
+                    }
+                }
+            }
+        }
+
+        if (isUndefined(self._rp_promise)) {
+            self._rp_promise = new Bluebird(function (resolve, reject) {
+                self._rp_resolve = resolve;
+                self._rp_reject = reject;
+            });
+
+            if (_useInMemoryCache(options)) {
+                self._rp_promise.then(_httpCacheHandler.bind(self));
+            }
+        }
 
         self._rp_callbackOrig = self.callback;
         self.callback = RP$callback;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
   "dependencies": {
     "bluebird": "^3.3",
     "lodash": "^4.6.1",
+    "memory-cache": "^0.1.5",
+    "q": "^1.4.1",
     "request": "^2.34"
   },
   "devDependencies": {
@@ -50,7 +52,8 @@
     "jshint": "2.9.x",
     "jshint-stylish": "2.1.x",
     "rimraf": "2.5.x",
-    "run-sequence": "1.1.x"
+    "run-sequence": "1.1.x",
+    "moment": "^2.13.0"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/test/spec/request-test.js
+++ b/test/spec/request-test.js
@@ -9,7 +9,10 @@ var childProcess = require('child_process');
 var path = require('path');
 var es = require('event-stream');
 var bodyParser = require('body-parser');
+var moment = require('moment');
+var crypto = require('crypto');
 
+var LAST_MODIFIED_FORMAT = 'ddd, DD MMM YYYY HH:mm:ss z';
 
 describe('Request-Promise', function () {
 
@@ -1389,7 +1392,6 @@ describe('Request-Promise', function () {
 
                     return rp(options)
                         .then(function (response) {
-                            console.log("DELETE succeeded with status %d", response.statusCode);
                             expect(response.statusCode).to.eql(200);
                         })
                         .catch(function (err) {
@@ -1425,4 +1427,414 @@ describe('Request-Promise', function () {
 
     });
 
+
+    describe('HTTP 1.1 Cache Implementation', function () {
+        var cacheServer;
+        var now = moment().format(LAST_MODIFIED_FORMAT);
+
+        var resources = [
+            {
+                headers: {
+                    'Last-Modified': now,
+                    'Cache-Control': 'public, max-age=10',
+                    'Content-Type': 'application/json',
+                    'Etag': 'resource_1'
+                },
+                content: {
+                    name: 'resource_1'
+                }
+            },
+            {
+                headers: {
+                    'Last-Modified': now,
+                    'Etag': 'resource_2',
+                    'Content-Type': 'application/json'
+                },
+                content: {
+                    name: 'resource_2'
+                }
+            },
+            {
+                headers: {
+                    'Last-Modified': now,
+                    'Etag': 'resource_3',
+                    'Cache-Control': 'no-cache',
+                    'Content-Type': 'application/json'
+                },
+                content: {
+                    name: 'resource_3'
+                }
+            },
+            {
+                headers: {
+                    'Last-Modified': now,
+                    'Etag': 'resource_4',
+                    'Cache-Control': 'no-cache',
+                    'Content-Type': 'application/json',
+                },
+                content: {
+                    name: 'resource_4'
+                }
+            },
+            {
+                headers: {
+                    'Last-Modified': now,
+                    'Etag': 'resource_5',
+                    'Cache-Control': 'no-cache',
+                    'Content-Type': 'application/json',
+                },
+                content: {
+                    name: 'resource_5'
+                }
+            },
+            {
+                headers: {
+                    'Last-Modified': now,
+                    'Etag': 'resource_6',
+                    'Cache-Control': 'public, max-age=30',
+                    'Content-Type': 'application/json',
+                    'age': 20
+                },
+                content: {
+                    name: 'resource_6'
+                }
+            },
+            {
+                headers: {
+                    'Last-Modified': now,
+                    'Cache-Control': 'public, max-age=10',
+                    'Content-Type': 'application/json',
+                    'Etag': 'resource_7'
+                },
+                content: {
+                    name: 'resource_7'
+                }
+            },
+
+
+        ];
+        var resourceOrigin = JSON.parse(JSON.stringify(resources));
+
+        // Increase Last-Modifier counter
+        var incrementLastModified = function (resource) {
+            var newDate = moment(resource.headers['Last-Modified'], LAST_MODIFIED_FORMAT).add(5, 'seconds');
+            resource.headers['Last-Modified'] = newDate.toString();
+            return resource.headers['Last-Modified'];
+        };
+
+        // Helper method to assert cached requests
+        var assertResponse = function(response, statusCode, content, lastModified, age) {
+            var headers = response.headers;
+
+            // console.info("\nResponse Headers: \n", response.headers);
+
+            expect(response.statusCode).to.eql(statusCode);
+            expect(JSON.parse(response.body).name).to.eql(content);
+            expect(headers['last-modified']).to.eql(lastModified);
+
+            if (typeof age === 'undefined') {
+                expect(typeof headers.age === 'undefined').to.eql(true);
+            } else if (age === 0) {
+                expect(parseInt(headers['age'])).to.eql(0);
+            } else {
+                expect(parseInt(headers['age']) > 0).to.eql(true);
+            }
+        };
+
+        var changeResource = function(resource) {
+            resource.content.name += 'salt';
+            resource.headers['Etag'] = resource.content.name + 'salt';
+        };
+
+        before(function (done) {
+            // This creates a local cache server to test cache behavior of the lib
+            cacheServer = http.createServer(function (request, response) {
+                (bodyParser.json())(request, response, function () {
+                    var index = parseInt(url.parse(request.url).pathname.substr(1).split('_')[1]) - 1;
+                    var resource = resources[index];
+
+                    if (resource) {
+                        var inm = request.headers['if-none-match'];
+                        var ims = request.headers['if-modified-since'];
+
+                        if (inm && inm === resource.headers['Etag']) {
+                            response.writeHead(304);
+                            response.end();
+                            return;
+                        }
+
+                        if (ims && ims !== resource.headers['Last-Modified']) {
+                            response.writeHead(304);
+                            response.end();
+                            return;
+                        }
+
+                        response.writeHead(200, resource.headers);
+                        response.end(JSON.stringify(resource.content));
+                    } else {
+                        response.writeHead(404);
+                        response.end('');
+                    }
+                });
+            });
+
+            cacheServer.listen(5000, function () {
+                done();
+            });
+        });
+
+        beforeEach(function() {
+            resources = JSON.parse(JSON.stringify(resourceOrigin));
+        });
+
+        after(function () {
+            cacheServer.close();
+        });
+
+        beforeEach(function () {
+            // Require a fresh lib
+            delete require.cache[require.resolve('../../lib/rp.js')];
+            rp = require('../../lib/rp.js');
+        });
+
+        it('should cache resource with: cache-control, cache option = true', function (done) {
+            var options = {
+                uri: 'http://localhost:5000/resource_1',
+                method: 'GET',
+                resolveWithFullResponse: true,
+                cache: true
+            };
+
+            rp(options).then(function (response) {
+                assertResponse(response, 200, 'resource_1', now, 0);
+
+                // Change the content to make sure it comes from the cache
+                resources[0].content.name = Math.random();
+
+                return rp(options);
+            })
+            .then(function (response) {
+                assertResponse(response, 200, 'resource_1', now, 1);
+
+                // Reset content
+                resources[0].content.name = 'resource_1';
+                done();
+            })
+            .catch(done);
+        });
+
+
+        it('should not cache resources with: no cache-control, cache option = true', function (done) {
+            var newRandomContent = Math.random();
+            var options = {
+                uri: 'http://localhost:5000/resource_2',
+                method: 'GET',
+                resolveWithFullResponse: true,
+                cache: true
+            };
+
+            rp(options).then(function (response) {
+                assertResponse(response, 200, 'resource_2', now, 0);
+
+                // Change the content to make sure it doesn't comes from the cache
+                resources[1].content.name = newRandomContent;
+
+                return rp(options);
+            })
+            .then(function (response) {
+                assertResponse(response, 200, newRandomContent, now, 0);
+
+                // Reset content
+                resources[1].content.name = 'resource_2';
+                done();
+            })
+            .catch(done);
+        });
+
+        it('should not cache resources with: cache-control no-cache, cache option = true', function (done) {
+            var options = {
+                uri: 'http://localhost:5000/resource_3',
+                cache: false,
+                resolveWithFullResponse: true
+            };
+
+            rp(options).then(function (response) {
+                assertResponse(response, 200, 'resource_3', now, undefined);
+                return rp(options);
+            }).then(function (response) {
+                assertResponse(response, 200, 'resource_3', now, undefined);
+                done();
+            }).catch(done);
+        });
+
+        it('should not cache resources with: cache-control, cache option = false', function (done) {
+            var options = {
+                uri: 'http://localhost:5000/resource_1',
+                resolveWithFullResponse: true,
+                cache: false
+            };
+
+            rp(options).then(function (response) {
+                assertResponse(response, 200, 'resource_1', now);
+
+                return rp(options);
+            })
+            .then(function (response) {
+                assertResponse(response, 200, 'resource_1', now);
+                done();
+            })
+            .catch(done);
+        });
+
+
+        it('should cache resource and deliver cached version regardless of Last-Modified changes', function (done) {
+            //
+            // @TODO Test isn't well isolated
+            //       Resource is already cached because of very first executed test
+            //
+
+            var options = {
+                uri: 'http://localhost:5000/resource_1',
+                resolveWithFullResponse: true,
+                cache: true
+            };
+
+            rp(options).then(function (response) {
+                assertResponse(response, 200, 'resource_1', now, true);
+                incrementLastModified(resources[0]);    // Age is still going to be smaller than max-age
+
+                return rp(options);
+            })
+            .then(function (response) {
+                assertResponse(response, 200, 'resource_1', now, true);
+                done();
+            })
+            .catch(done);
+        });
+
+        it('should cache resource and deliver a fresh resource (invalidation through Last-Modified)', function (done) {
+            this.timeout(11000);
+
+            var options = {
+                uri: 'http://localhost:5000/resource_4',
+                resolveWithFullResponse: true,
+                cache: true
+            };
+
+            rp(options).then(function (response) {
+                assertResponse(response, 200, 'resource_4', now, 0);
+                var later = incrementLastModified(resources[3]);
+
+                console.log('waiting (6s) for resource to expire...');
+                setTimeout(function () {
+                    rp(options).then(function (response) {
+                        assertResponse(response, 200, 'resource_4', later, 0);
+                        done();
+                    });
+                }, 6000);
+            })
+            .catch(done);
+        });
+
+        it('should cache resource and further deliver the stale because neither last-modified nor etag has changed (conditional request returns 304)', function (done) {
+            this.timeout(30000);
+
+            var options = {
+                uri: 'http://localhost:5000/resource_7',
+                resolveWithFullResponse: true,
+                cache: true,
+                simple: false
+            };
+
+            rp(options).then(function (response) {
+                assertResponse(response, 200, 'resource_7', now, 0);
+                // change content
+                resources[0].content.name = 'resource_7_salt';
+
+                console.log('waiting (11s) for resource to expire...');
+                setTimeout(function () {
+                    rp(options).then(function (response) {
+                        // content should still be resource_7 because conditional requests should
+                        // return 304
+                        // age is reset to 0 by the cache in that case
+                        assertResponse(response, 200, 'resource_7', now, 0);
+                        done();
+                    });
+                }, 11000);
+            })
+            .catch(done);
+        });
+
+
+        it('should cache resource and deliver a fresh resource (invalidation through ETag)', function (done) {
+            this.timeout(11000);
+
+            var options = {
+                uri: 'http://localhost:5000/resource_5',
+                method: 'GET',
+                resolveWithFullResponse: true,
+                cache: true
+            };
+
+            rp(options).then(function(response){
+                assertResponse(response, 200, 'resource_5', now, 0);
+
+                // change the ETag
+                changeResource(resources[4]);
+                console.log('waiting (6s) for resource to expire...');
+                setTimeout(function() {
+                    rp(options).then(function(response){
+                        assertResponse(response, 200, 'resource_5salt', now, 0);
+                        done();
+                    });
+                }, 6000);
+            });
+
+        });
+
+        it('should cache resource and deliver a fresh resource not incremented (invalidation)', function (done) {
+            this.timeout(20000);
+
+            var options = {
+                uri: 'http://localhost:5000/resource_1',
+                method: 'GET',
+                cache: true,
+                resolveWithFullResponse: true
+            };
+
+            rp(options).then(function (response) {
+                assertResponse(response, 200, 'resource_1', now, 0);
+                console.log('waiting (11s) for resource to expire...');
+                setTimeout(function() {
+                    rp(options).then(function (response) {
+                        assertResponse(response, 200, 'resource_1', now, 0);
+                        done();
+                    });
+                }, 11000);
+            });
+        });
+
+        it('should cache resource and deliver a fresh resource (invalidation)', function (done) {
+            this.timeout(11000);
+
+            var options = {
+                uri: 'http://localhost:5000/resource_6',
+                method: 'GET',
+                cache: true,
+                resolveWithFullResponse: true
+            };
+
+            rp(options).then(function (response) {
+                assertResponse(response, 200, 'resource_6', now, 20);
+
+                rp(options).then(function (response) {
+                    expect(response.statusCode).to.eql(200);
+                    expect(response.headers['last-modified']).to.eql(now);
+                    expect(parseInt(response.headers['age']) > 20).to.eql(true);
+                    done();
+                });
+            });
+        });
+
+    });
 });


### PR DESCRIPTION
Some point to add in the future documentation on the extension we are provided :
- we are trying the recent RFC of HTTP 1.1 on conditional requests for cache invalidation : the implementation does not support the full standard though (but easy to extend)
- we just support cache-control header and Expires header is ignored
- in the cache-control header we do not interpret max-stale, no-store, no-transform, min-fresh, min-vers
for whole the cached resource we behave as if the cache-control would have the must-revalidate value (among all we return 504 if revalidation request returns a 404)
- having public or private in the cache-control does not play a role in the behavior of our cache
- the lib should deliver the cached resource with an `Age` header calculated with the stored metadata from the cached resource