### PR TITLE
Add cancellation support

### DIFF
--- a/lib/rp.js
+++ b/lib/rp.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Bluebird = require('bluebird'),
+var Bluebird = require('bluebird').getNewLibraryCopy(),
     configure = require('@request/promise-core/configure/request2'),
     stealthyRequire = require('stealthy-require');
 
@@ -20,6 +20,7 @@ try {
     throw err;
 }
 
+Bluebird.config({cancellation: true});
 
 configure({
     request: request,
@@ -28,10 +29,16 @@ configure({
         'then',
         'catch',
         'finally',
+        'cancel',
         'promise'
-    ]
+    ],
+    constructorMixin: function (resolve, reject, onCancel) {
+        var self = this;
+        onCancel(function () {
+            self.abort();
+        });
+    }
 });
-
 
 request.bindCLS = function RP$bindCLS() {
     throw new Error('CLS support was dropped. To get it back read: https://github.com/request/request-promise/wiki/Getting-Back-Support-for-Continuation-Local-Storage');

--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -19,6 +19,9 @@ module.exports = function startServer(port, cb) {
                     res.writeHead(301, { Location: '/200' });
                     res.end();
                     break;
+                case 503:
+                    // Send no response at all
+                    break;
                 default:
                     res.writeHead(status, {'Content-Type': 'text/plain'});
                     var body = req.method === 'POST' ? ' - ' + JSON.stringify(req.body) : '';

--- a/test/spec/request-test.js
+++ b/test/spec/request-test.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var Bluebird = require('bluebird'),
-    childProcess = require('child_process'),
+var childProcess = require('child_process'),
     errors = require('../../errors'),
     path = require('path'),
     rp = require('../../'),
@@ -78,10 +77,27 @@ describe('Request-Promise', function () {
 
             var p = rp('http://localhost:4000/200').promise();
 
-            expect(p instanceof Bluebird).to.eql(true);
+            // This will not actually be an instanceof Bluebird since request-promise creates a new Bluebird copy.
+            // Instead, verify that the Promise contains the bluebird functions.
+            expect(p.constructor.name).to.equal('Promise');
+            expect(p.then).to.be.a('function');
+            expect(p.delay).to.be.a('function');
+            expect(p.map).to.be.a('function');
+            expect(p.cancel).to.be.a('function');
 
         });
 
+        it('.cancel() cancelling the Bluebird promise and aborting the request', function (done) {
+            var req = rp('http://localhost:4000/503');
+            req.once('abort', done);
+            req.cancel();
+        });
+
+        it('.cancel() on promises chained from the Bluebird promise, aborting the request', function (done) {
+            var req = rp('http://localhost:4000/503');
+            req.once('abort', done);
+            req.then(function noop() { }).cancel();
+        });
     });
 
     describe('should still allow to require Request independently', function () {


### PR DESCRIPTION
Fixes #113

This change adds bluebird's `.cancel` function to all request objects from request-promise. When the `.cancel` function is called, the Promise is cancelled, and the corresponding request is aborted.