### PR TITLE
Changed versioning system in package.json to caret based instead of fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,23 +34,23 @@
     "request": "^2.34"
   },
   "devDependencies": {
-    "body-parser": "1.15.x",
-    "chai": "3.5.x",
-    "chai-as-promised": "5.2.x",
-    "chalk": "1.1.x",
-    "cheerio": "0.20.x",
+    "body-parser": "^1.15.x",
+    "chai": "^3.5.x",
+    "chai-as-promised": "^5.2.x",
+    "chalk": "^1.1.x",
+    "cheerio": "^0.20.x",
     "cls-bluebird": "^1.0.1",
     "continuation-local-storage": "^3.1.4",
-    "event-stream": "3.3.x",
-    "gulp": "3.9.x",
-    "gulp-coveralls": "0.1.x",
-    "gulp-istanbul": "0.10.x",
-    "gulp-jshint": "2.0.x",
-    "gulp-mocha": "2.2.x",
-    "jshint": "2.9.x",
-    "jshint-stylish": "2.1.x",
-    "rimraf": "2.5.x",
-    "run-sequence": "1.1.x"
+    "event-stream": "^3.3.x",
+    "gulp": "^3.9.x",
+    "gulp-coveralls": "^0.1.x",
+    "gulp-istanbul": "^0.10.x",
+    "gulp-jshint": "^2.0.x",
+    "gulp-mocha": "^2.2.x",
+    "jshint": "^2.9.x",
+    "jshint-stylish": "^2.1.x",
+    "rimraf": "^2.5.x",
+    "run-sequence": "^1.1.x"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Hi there,

I see that in your package.json , versioning of dependencies required were inconsistent some are used with preferred "^"(Caret) based semantic versioning and some were fixed based . So in ther PR i changed whole versioning system to  Caret based (^).

So what's the advantage we'll get from changing it to Caret based . Well if you see [npm docs](https://docs.npmjs.com/cli/update). 

They clearly states that by using fixed dependencies version when there is new version available for that package. 
`npm outdated` would show something like 
![image](https://cloud.githubusercontent.com/assets/10435209/15947127/96e24e88-2eb7-11e6-81c5-f9c06df5f021.png)

As you can see latest version is greater and considered to be feature update/rich that old veriosn. Now as we are using fixed versioning our 'Wanted' column in above image shows what our fixed version is. Now even if we try to update those by using `npm update` they wont update because Wanted and Current version are same.


Now if change it to "^" bases versioning we would see result of `npm outdated` like below :-
![image](https://cloud.githubusercontent.com/assets/10435209/15947216/0822c2b2-2eb8-11e6-9406-ac265def6165.png)


Now as you can see wanted and current differs now and if we now run `npm update` it will actually update our package to latest version wanted.


Now to handle major changes like that happened when express moved from 3.x.x to 4.x.x  and everything used in express 3.x.x wont work in 4.x.x ; npm does a trick that when using caret based system it only updates your package if from major.minor.patch , minor / patch differs in wanted and current version. If we use "~" based versioning then it will check for patch only and it will check none in case of fixed versioning.

If there is major version update it wont update it . you have to do it manually. So this way i see no reason why we should not use Caret based versioning and try to be consistent.
Please ignore any typos or grammatical errors.
Thanks & Regards,
Tarun Garg