### PR TITLE
Make travis use latest stable release of node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,7 @@ language: node_js
 sudo: false
 
 node_js:
-  - "0.10"
-  - "0.12"
-  - "iojs"
-  - "4"
-  - "6"
+  - "node"
 
 env:
   - V_REQUEST=2.34.0


### PR DESCRIPTION
Hi,

Again a PR related to versioning issue.

Now in travis build we were previously using io.js and old node.js version. Now as travis [docs](https://docs.travis-ci.com/user/languages/javascript-with-nodejs) says that you only can specify node and it will automatically pickup latest stable release of node for its nvm and test our source code on that.

Now using latest release is mandatory because now with advent of ES6 and node supporting 93% of ES6 features there is no sense why should not use ES6 in node.js and  why we should not use latest version of nvm and test our code against that  .

Thanks & Regards,
Tarun Garg