### PR TITLE
Bluebird as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   },
   "dependencies": {
     "request-promise-core": "1.1.1",
-    "bluebird": "^3.4.1",
     "stealthy-require": "^1.0.0"
   },
   "peerDependencies": {
-    "request": "^2.34"
+    "request": "^2.34",
+    "bluebird": ">=3.4.1"
   },
   "devDependencies": {
     "body-parser": "~1.15.2",


### PR DESCRIPTION
The Bluebird installation of the host package should be used if it's available, as the package consumer needs consistency in Promise behaviour across the application.