### PR TITLE
upgrade bluebird to 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "request-promise-core": "1.1.1",
-    "bluebird": "^3.4.1",
+    "bluebird": "^3.5.0",
     "stealthy-require": "^1.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
test pass locally.

if #169 is still unpalatable, https://greenkeeper.io/ is a great solution to keep all package upgrades managed and tested.

