### PR TITLE
Expose tap method from Bluebird

### DIFF
--- a/lib/rp.js
+++ b/lib/rp.js
@@ -30,7 +30,8 @@ configure({
         'catch',
         'finally',
         'cancel',
-        'promise'
+        'promise',
+        'tap'
     ],
     constructorMixin: function (resolve, reject, onCancel) {
         var self = this;


### PR DESCRIPTION
Just curious if there's any specific reason it's being excluded — we use `.tap` in our project pretty often for logging, etc.