### PR TITLE
Export .tap(...) function

### DIFF
--- a/lib/rp.js
+++ b/lib/rp.js
@@ -30,6 +30,7 @@ configure({
     PromiseImpl: Bluebird,
     expose: [
         'then',
+        'tap',
         'catch',
         'finally',
         'cancel',

--- a/test/spec/request-test.js
+++ b/test/spec/request-test.js
@@ -41,6 +41,24 @@ describe('Request-Promise', function () {
                 });
 
         });
+        it('.tap(...)', function (done) {
+            var tapWasCalled = false;
+            rp('http://localhost:4000/200')
+                .tap(function (body) {
+                    expect(body).to.eql('GET /200');
+                    tapWasCalled = true;
+                    return;
+                })
+                .then(function (body) {
+                    expect(body).to.eql('GET /200');
+                    expect(tapWasCalled).to.eql(true);
+                    done();
+                })
+                .catch(function (err) {
+                    done(err);
+                });
+
+        });
 
         it('.catch(...) and the error types', function (done) {
 


### PR DESCRIPTION
I think it would be useful to expose the `tap` function too.

```
rq(options)
.tap(function(response) {
// Whatever async you want to do with the response, like save it in the logs elasticsearch
})
.then(function(response) {
// still the response :)
});
```

instead of:

```
rq(options)
.then(function(response) {
// Whatever async you want to do with the response, like save it in the logs elasticsearch
return response;
})
.then(function(response) {
// still the response :)
});


```