### PR TITLE
Update README.md to correct the formData content-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ var options = {
         }
     },
     headers: {
-        /* 'content-type': 'application/x-www-form-urlencoded' */ // Is set automatically
+        /* 'content-type': 'multipart/form-data' */ // Is set automatically
     }
 };
 


### PR DESCRIPTION
According to request document (https://github.com/request/request#forms), `formData` generates `content-type` as `multipart/form-data`

If you want to have application/x-www-form-urlencoded, use `form`