### PR TITLE
Upgrade tough-cookie to a version without regex DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "request-promise-core": "1.1.1",
     "bluebird": "^3.5.0",
     "stealthy-require": "^1.1.0",
-    "tough-cookie": ">=2.3.0"
+    "tough-cookie": ">=2.3.3"
   },
   "peerDependencies": {
     "request": "^2.34"


### PR DESCRIPTION
`tough-cookie` version <=2.3.2 is currently vulnerable to a regex denial of service attack. See https://nodesecurity.io/advisories/525.

This issue has been fixed in `tough-cookie` v2.3.3. See https://github.com/salesforce/tough-cookie/issues/92.