### PR TITLE
bump request

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gulp-mocha": "~2.2.0",
     "lodash": "~4.13.1",
     "publish-please": "~2.1.4",
-    "request": "^2.34.0",
+    "request": "^2.88.0",
     "rimraf": "~2.5.3",
     "run-sequence": "~1.2.2"
   }


### PR DESCRIPTION
this library must always use the latest version of request, makes sense right?