### PR TITLE
Limit the tough-cookie to 2.5 as 3.x removes node 0.10 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "request-promise-core": "1.1.1",
     "bluebird": "^3.5.0",
     "stealthy-require": "^1.1.0",
-    "tough-cookie": ">=2.3.3"
+    "tough-cookie": "^2.5.0"
   },
   "peerDependencies": {
     "request": "^2.34"

--- a/test/spec/request-test.js
+++ b/test/spec/request-test.js
@@ -208,7 +208,7 @@ describe('Request-Promise', function () {
         var cookiejar = rp.jar();
 
         expect(function () {
-            cookiejar.setCookie(sessionCookie, 'https://api.mydomain.com');
+            cookiejar.setCookie(sessionCookie.toString(), 'https://api.mydomain.com');
         }).to.not.throw();
 
     });


### PR DESCRIPTION
Latest tough-cookie does not have node 0.10 support. Update the package.json to limit to the 2.5 version.